### PR TITLE
Update widgets.py

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -329,6 +329,14 @@ class SimpleArrayWidget(Widget):
 
     :param separator: Defaults to ``','``
     """
+    if type(value) == list:
+        if len(value) != 0:
+            if type(value[0]) == int:
+                value = ",".join(str(num) for num in value)
+            else:
+                value = ",".join(value)
+    else:
+        pass
 
     def __init__(self, separator=None):
         if separator is None:


### PR DESCRIPTION


**Problem**

previously in django when using arrayfield model from postgresql we could not import an array directly into arrayfield it would always give some error so i modified it so that the arrayflied will store the entire array as intended  the error was due to the fact that in the simplearraywidget class it was expecting a string rather than an array

**Solution**

i made changes in clean function giving it the desired string instead of an array 


**Acceptance Criteria**

i made a project using this and i was able to import successfully an array but it was a long time ago and i dont have any screenshots of that now  